### PR TITLE
Make the action to upload both sarif and astgrep signals

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,9 +1,7 @@
 runner:
   mypy:
-    cmd: mypy ./
+    cmd: mypy .
     format: mypy
   ruff:
-    cmd: ruff check .
-    errorformat:
-      - "%f:%l:%c: %m"
-    name: ruff
+    cmd: ruff check --output-format=sarif
+    format: sarif

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Aviator Signals"
-description: "Runs linters and sends the output to aviator/api/signals."
+description: "Upload the signals to Aviator."
 branding:
   color: yellow
   icon: activity
@@ -10,44 +10,33 @@ runs:
     with:
       filter: 'blob:none'
 
-  # todo: only changed files?
-
   - uses: actions/setup-python@v5
     with:
       python-version: "3.12"
       cache: "pip"
 
   - name: Install dependencies
-    run: |
-      pip install requests
-      pip install ruff
+    run: pip install requests
     shell: sh
 
-  - name: Setup reviewdog
-    uses: reviewdog/action-setup@v1
-    with:
-      reviewdog_version: latest
-
-  - name: Show Current Directory
-    run: pwd
-    shell: sh
-
-  - name: List Files
-    run: ls -la
-    shell: sh
-
-  - name: Run linters
-    run: python $GITHUB_ACTION_PATH/action.py path=$GITHUB_ACTION_PATH
+  - name: Run uploader
+    run: python $GITHUB_ACTION_PATH/action.py
     shell: sh
     env:
-      ACTION_PATH: $GITHUB_ACTION_PATH
+      GITHUB_SHA: ${{ github.sha }}
+      REPO_NAME: ${{ github.repository }}
       AVIATOR_API_TOKEN: ${{ inputs.aviator-api-token }}
-      OWNER: ${{ inputs.owner }}
+      INPUT_FORMAT: ${{ inputs.format }}
+      FILE_PATHS: ${{ inputs.file-paths }}
 
 inputs:
   aviator-api-token:
     description: "The Aviator API token"
     required: true
-  owner:
-    description: "The owner of the repository"
+  file-paths:
+    description: "The comma-separated glob paths to the input files"
     required: true
+  format:
+    description: "The format of the signals ('sarif' or 'astgrep')"
+    required: false
+    default: "sarif"


### PR DESCRIPTION
Instead of running the linters within this action, delegate that part to
the caller and make this action responsible for uploading the results of
the linters. This way, the users can just pick whatever linter they want
to use and then use this action to upload the results to Aviator.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
